### PR TITLE
🐛 ios: fix `none` and default attestation kind

### DIFF
--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -61,8 +61,10 @@ internal enum AttestationConveyancePreference: String, Enumerable {
             return ASAuthorizationPublicKeyCredentialAttestationKind.indirect
         case .enterprise:
             return ASAuthorizationPublicKeyCredentialAttestationKind.enterprise
+        case .none:
+            return ASAuthorizationPublicKeyCredentialAttestationKind.none
         default:
-            return ASAuthorizationPublicKeyCredentialAttestationKind.direct
+            return ASAuthorizationPublicKeyCredentialAttestationKind.none
         }
     }
 }


### PR DESCRIPTION
# issue
in the `AttestationConveyancePreference.appleise` function, the `none` value case is not covered, and the default case (which should be `none`) is wrongly returning `direct`, making it effectively impossible to pass the actual _appleised_ `none` value. this is especially bad because `none` seems to be currently the only supported value for `ASAuthorizationPublicKeyCredentialRegistrationRequest.attestationPreference`.
