### PR TITLE
feat: adds an ios.requireBiometrics config flag

### DIFF
--- a/.changeset/afraid-points-brush.md
+++ b/.changeset/afraid-points-brush.md
@@ -1,0 +1,5 @@
+---
+"react-native-passkeys": minor
+---
+
+Adds an `ios.requireBiometrics` flag to specify the LAPolicy required

--- a/example/src/app/index.tsx
+++ b/example/src/app/index.tsx
@@ -79,7 +79,7 @@ export default function App() {
 	>(null);
 	const [credentialId, setCredentialId] = React.useState("");
 
-	const createPasskey = async () => {
+	const createPasskey = async (config?: passkey.PasskeysConfig) => {
 		try {
 			const json = await passkey.create({
 				challenge,
@@ -90,7 +90,7 @@ export default function App() {
 				...(Platform.OS !== "android" && {
 					extensions: { largeBlob: { support: "required" } },
 				}),
-			});
+			}, config);
 
 			console.log("creation json -", json);
 
@@ -103,14 +103,14 @@ export default function App() {
 		}
 	};
 
-	const authenticatePasskey = async () => {
+	const authenticatePasskey = async (config?: passkey.PasskeysConfig) => {
 		const json = await passkey.get({
 			rpId: rp.id,
 			challenge,
 			...(credentialId && {
 				allowCredentials: [{ id: credentialId, type: "public-key" }],
 			}),
-		});
+		}, config);
 
 		console.log("authentication json -", json);
 
@@ -176,11 +176,17 @@ export default function App() {
 				<Text>Passkeys are {passkey.isSupported() ? "Supported" : "Not Supported"}</Text>
 				{credentialId && <Text>User Credential ID: {credentialId}</Text>}
 				<View style={styles.buttonContainer}>
-					<Pressable style={styles.button} onPress={createPasskey}>
+					<Pressable style={styles.button} onPress={() => createPasskey()}>
 						<Text>Create</Text>
 					</Pressable>
-					<Pressable style={styles.button} onPress={authenticatePasskey}>
+					<Pressable style={styles.button} onPress={() => createPasskey({ios:{requireBiometrics: false}})}>
+						<Text>Create (biometrics not required)</Text>
+					</Pressable>
+					<Pressable style={styles.button} onPress={() => authenticatePasskey()}>
 						<Text>Authenticate</Text>
+					</Pressable>
+					<Pressable style={styles.button} onPress={() => authenticatePasskey({ios:{requireBiometrics: false}})}>
+						<Text>Authenticate (biometrics not required)</Text>
 					</Pressable>
 					<Pressable style={styles.button} onPress={writeBlob}>
 						<Text>Add Blob</Text>

--- a/ios/ReactNativePasskeysModule.swift
+++ b/ios/ReactNativePasskeysModule.swift
@@ -25,11 +25,11 @@ final public class ReactNativePasskeysModule: Module, PasskeyResultHandler {
       return false
     }
 
-    AsyncFunction("get") { (request: PublicKeyCredentialRequestOptions, promise: Promise) throws in
+    AsyncFunction("get") { (request: PublicKeyCredentialRequestOptions, requireBiometrics: Bool, promise: Promise) throws in
         do { 
             // - all the throws are already in the helper `isAvailable` so we don't need to do anything
             // ? this seems like a code smell ... what is the best way to do this
-            let _ = try isAvailable() 
+            let _ = try isAvailable(requireBiometrics: requireBiometrics)
         } 
         catch let error {
             throw error
@@ -49,11 +49,11 @@ final public class ReactNativePasskeysModule: Module, PasskeyResultHandler {
         passkeyDelegate.performAuthForController(controller: authController);
     }.runOnQueue(.main)
 
-    AsyncFunction("create") { (request: PublicKeyCredentialCreationOptions, promise: Promise) throws in
+    AsyncFunction("create") { (request: PublicKeyCredentialCreationOptions, requireBiometrics: Bool, promise: Promise) throws in
         do { 
             // - all the throws are already in the helper `isAvailable` so we don't need to do anything
             // ? this seems like a code smell ... what is the best way to do this
-            let _ = try isAvailable() 
+            let _ = try isAvailable(requireBiometrics: requireBiometrics)
         } 
         catch let error {
             throw error
@@ -98,7 +98,7 @@ final public class ReactNativePasskeysModule: Module, PasskeyResultHandler {
       
   }
 
-  private func isAvailable() throws -> Bool {
+  private func isAvailable(requireBiometrics: Bool = true) throws -> Bool {
     if #unavailable(iOS 15.0) {
         throw NotSupportedException()
     }
@@ -107,7 +107,15 @@ final public class ReactNativePasskeysModule: Module, PasskeyResultHandler {
         throw PendingPasskeyRequestException()
     }
 
-    if LAContext().biometricType == .none {
+    let context = LAContext()
+
+    // Check the local authentication policy can be evaluated
+    let policy: LAPolicy = requireBiometrics ? .deviceOwnerAuthenticationWithBiometrics : .deviceOwnerAuthentication
+    guard context.canEvaluatePolicy(policy, error: nil) else {
+        throw BiometricException()
+    }
+
+    if requireBiometrics && context.biometricType == .none {
         throw BiometricException()
     }
 
@@ -315,11 +323,6 @@ extension LAContext {
 
     var biometricType: BiometricType {
         var error: NSError?
-
-        guard self.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
-            // Capture these recoverable error thru Crashlytics
-            return .none
-        }
 
         if #available(iOS 11.0, *) {
             switch self.biometryType {

--- a/src/ReactNativePasskeysModule.ts
+++ b/src/ReactNativePasskeysModule.ts
@@ -1,7 +1,9 @@
-import { requireNativeModule } from "expo-modules-core";
+import { Platform, requireNativeModule } from "expo-modules-core";
 import type {
 	PublicKeyCredentialCreationOptionsJSON,
 	RegistrationResponseJSON,
+	PublicKeyCredentialRequestOptionsJSON,
+	AuthenticationResponseJSON,
 } from "./ReactNativePasskeys.types";
 import { NotSupportedError } from "./errors";
 
@@ -12,12 +14,26 @@ const passkeys = requireNativeModule("ReactNativePasskeys");
 export default {
 	...passkeys,
 
+	async get(
+		request: PublicKeyCredentialRequestOptionsJSON,
+		requireBiometrics: boolean
+	): Promise<AuthenticationResponseJSON | null> {
+		return Platform.OS === "ios"
+			? await passkeys.get(request, requireBiometrics)
+			: await passkeys.get(request);
+	},
+
 	async create(
 		request: PublicKeyCredentialCreationOptionsJSON,
+		requireBiometrics: boolean
 	): Promise<RegistrationResponseJSON | null> {
 		if (!this.isSupported) throw new NotSupportedError();
 
-		const credential = await passkeys.create(request);
+		const credential =
+			Platform.OS === "ios"
+				? await passkeys.create(request, requireBiometrics)
+				: await passkeys.create(request);
+
 		return {
 			...credential,
 			response: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,15 +22,41 @@ export function isAutoFillAvalilable(): boolean {
 	return ReactNativePasskeysModule.isAutoFillAvalilable()
 }
 
+export interface PasskeysConfig {
+  /**
+   * Options and configuration specific to the iOS platform.
+   */
+  ios?: {
+    /**
+     * Defines the [local authentication policy](https://developer.apple.com/documentation/localauthentication/lapolicy) to use:
+     * - `true`: Use the `deviceOwnerAuthenticationWithBiometrics` policy.
+     * - `false`: Use the `deviceOwnerAuthentication` policy.
+     * Defaults to `true`.
+     *
+     * @see {@linkcode https://developer.apple.com/documentation/localauthentication/lapolicy/deviceownerauthenticationwithbiometrics|LAPolicy.deviceOwnerAuthenticationWithBiometrics}
+     * @see {@linkcode https://developer.apple.com/documentation/localauthentication/lapolicy/deviceownerauthentication|LAPolicy.deviceOwnerAuthentication}
+     */
+    requireBiometrics?: boolean
+  }
+}
+
+export interface PasskeysCreateOptions extends PasskeysConfig {}
+
 export async function create(
 	request: Omit<PublicKeyCredentialCreationOptionsJSON, 'extensions'> & {
 		// - only largeBlob is supported currently on iOS
 		// - no extensions are currently supported on Android
 		extensions?: { largeBlob?: AuthenticationExtensionsLargeBlobInputs }
 	} & Pick<CredentialCreationOptions, 'signal'>,
+	options?: PasskeysCreateOptions
 ): Promise<RegistrationResponseJSON | null> {
-	return await ReactNativePasskeysModule.create(request)
+  return ReactNativePasskeysModule.create(
+    request,
+    options?.ios?.requireBiometrics ?? true
+  )
 }
+
+export interface PasskeysGetOptions extends PasskeysConfig {}
 
 export async function get(
 	request: Omit<PublicKeyCredentialRequestOptionsJSON, 'extensions'> & {
@@ -38,6 +64,10 @@ export async function get(
 		// - no extensions are currently supported on Android
 		extensions?: { largeBlob?: AuthenticationExtensionsLargeBlobInputs }
 	},
+	options?: PasskeysGetOptions
 ): Promise<AuthenticationResponseJSON | null> {
-	return ReactNativePasskeysModule.get(request)
+  return ReactNativePasskeysModule.get(
+    request,
+    options?.ios?.requireBiometrics ?? true
+  )
 }


### PR DESCRIPTION
## Summary

Adds a new configuration flag to both `create` and `get` enabling a more lenient policy (`deviceOwnerAuthentication`) if the strong version (`deviceOwnerAuthenticationWithBiometrics`) is not desired.

Closes #36

## Implementation details

Defined a new configuration object (type `PasskeysConfig`) shared between the two calls (`create`/`get`) but extended by their own interfaces (`PasskeysCreateOptions`,`PasskeysGetOptions`) for if/when we want to add new properties specific to each. This config object is documented (via JSDoc) and the flag is specified under `ios` to make it clear it is platform-specific.

Because the option is relevant only to the iOS variant of the native module, `Platform.OS` is used in the `src/ReactNativePasskeysModule.ts` to differentiate which arguments need to be passed in. This is inspired by the pattern used by Expo, for example [in their `WebBrowser` module, `openAuthSessionAsync` method](https://github.com/expo/expo/blob/ca153e599bd39cd950d6ec0526698e4f682ff9a2/packages/expo-web-browser/src/WebBrowser.ts#L234).

Finally, in the iOS module itself, the core of the implementation change lives in the `isAvailable` method, now responsible for `canEvaluatePolicy`  depending on the `requireBiometrics` option, and conditionally checking `biometricType` like before.

## Testing

Tested in an iOS device with Face ID disabled, with the new option added to the test app:

- [x] Using 'create' (no arguments) throws due to biometrics not being available.
- [x] Using 'authenticate' (no arguments) throws due to biometrics not being available.
- [x] Using 'create' (biometrics not requires) performs as expected.
- [x] Using 'authenticate' (biometrics not requires) performs as expected.

Also tested in an Android device to validate other platforms were not affected.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control whether biometric authentication is required for passkey operations on iOS devices.
  - Introduced new configuration options for passkey creation and authentication, allowing users to enable or disable biometric requirements.
  - Updated the app interface to provide buttons for both biometric-required and biometric-optional passkey flows.

- **Chores**
  - Documented the new configuration option in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->