### PR TITLE
Feat: Improved error logs on android and remove logs

### DIFF
--- a/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
+++ b/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
@@ -98,7 +98,9 @@ class ReactNativePasskeysModule : Module() {
     private fun getRegistrationException(e: CreateCredentialException) =
         when (e) {
             is CreatePublicKeyCredentialDomException -> {
-                e.domError.toString()
+                val errorType = e.domError.javaClass.simpleName
+                val errorMessage = e.message ?: "Unknown error"
+                "DomError: $errorType - $errorMessage"
             }
 
             is CreateCredentialCancellationException -> {
@@ -127,7 +129,9 @@ class ReactNativePasskeysModule : Module() {
     private fun getAuthenticationException(e: GetCredentialException) =
         when (e) {
             is GetPublicKeyCredentialDomException -> {
-                e.domError.toString()
+                val errorType = e.domError.javaClass.simpleName
+                val errorMessage = e.message ?: "Unknown error"
+                "DomError: $errorType - $errorMessage"
             }
 
             is GetCredentialCancellationException -> {

--- a/src/ReactNativePasskeysModule.web.ts
+++ b/src/ReactNativePasskeysModule.web.ts
@@ -193,7 +193,6 @@ const warnUserOfMissingWebauthnExtensions = (
 ) => {
 	if (clientExtensionResults) {
 		for (const key in requestedExtensions) {
-			console.log(key, clientExtensionResults[key]);
 			if (typeof clientExtensionResults[key] === "undefined") {
 				alert(
 					`Webauthn extension ${key} is undefined -- your browser probably doesn't know about it`,

--- a/src/utils/warn-user-of-missing-webauthn-extensions.ts
+++ b/src/utils/warn-user-of-missing-webauthn-extensions.ts
@@ -12,7 +12,6 @@ export const warnUserOfMissingWebauthnExtensions = (
 ) => {
 	if (clientExtensionResults) {
 		for (const key in requestedExtensions) {
-			console.log(key, clientExtensionResults[key]);
 			if (typeof clientExtensionResults[key] === "undefined") {
 				alert(
 					`Webauthn extension ${key} is undefined -- your browser probably doesn't know about it`,


### PR DESCRIPTION
Instead of just getting errors like this: ``androidx.credentials.exceptions.domerrors.DataError@85a93b2`` one now gets more info on what was the issue like so for instance : ``DomError: DataError - [50152] RP ID cannot be validated.``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Enhanced Android error messages for passkey registration and authentication failures by including the DOM error type and detailed message, improving clarity when issues occur.
- Chores
  - Reduced console noise on web by removing debug logs when requested WebAuthn extensions are unavailable; behavior and alerts remain unchanged.
  - Streamlined the utility handling missing extensions to avoid logging internal keys while preserving user-facing warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->