### PR TITLE
Fix iOS error handling for excludeCredentials (issue #45)

### DIFF
--- a/.changeset/fix-invalid-state-error-45.md
+++ b/.changeset/fix-invalid-state-error-45.md
@@ -1,0 +1,14 @@
+---
+"react-native-passkeys": patch
+---
+
+Fix iOS error handling to provide descriptive error messages for excludeCredentials
+
+Previously, iOS would return generic error messages like "(null)" or "The operation couldn't be completed" when handling excludeCredentials errors. This fix enhances error handling on iOS to detect generic error messages and replace them with clear, descriptive messages that match the WebAuthn specification.
+
+Changes:
+- Added detection for generic/useless error messages from iOS
+- Map ASAuthorizationError codes to proper WebAuthn error names
+- Return descriptive error messages for all error cases including InvalidStateError for excludeCredentials
+
+Fixes #45

--- a/example/src/app/index.tsx
+++ b/example/src/app/index.tsx
@@ -215,6 +215,29 @@ export default function App() {
 		setResult(json);
 	};
 
+	const testExcludeCredentials = async () => {
+		if (!credentialId) {
+			alert("No credential", "Create a passkey first to test excludeCredentials");
+			return;
+		}
+
+		try {
+			// Attempt to create a new passkey with the existing credential in excludeCredentials
+			// This should fail with InvalidStateError
+			const json = await passkey.create({
+				...createOptions,
+				excludeCredentials: [{ id: credentialId, type: "public-key" }],
+			});
+
+			console.log("excludeCredentials test result -", json);
+			alert("Unexpected Success", "This should have failed with InvalidStateError");
+			setResult(json);
+		} catch (e) {
+			console.error("excludeCredentials error (expected) -", e);
+			alert("Expected Error (Issue #45)", JSON.stringify(e, null, 2));
+		}
+	};
+
 	return (
 		<View style={{ flex: 1 }}>
 			<ScrollView
@@ -237,6 +260,9 @@ export default function App() {
 					</Pressable>
 					<Pressable style={styles.button} onPress={authenticatePasskey}>
 						<Text>Authenticate</Text>
+					</Pressable>
+					<Pressable style={styles.button} onPress={testExcludeCredentials}>
+						<Text>Test excludeCredentials</Text>
 					</Pressable>
 					<Pressable style={styles.button} onPress={writeBlob}>
 						<Text>Add Blob</Text>

--- a/ios/PasskeyExceptions.swift
+++ b/ios/PasskeyExceptions.swift
@@ -25,9 +25,8 @@ internal class BiometricException: Exception {
 }
 
 internal class UserCancelledException: Exception {
-  override var reason: String {
-    "User cancelled the passkey interaction"
-  }
+  // Don't override reason - use the description passed to the initializer
+  // Maps to WebAuthn NotAllowedError
 }
 
 internal class InvalidChallengeException: Exception {
@@ -67,13 +66,32 @@ internal class InvalidPRFInputException: Exception {
 }
 
 internal class UnknownException: Exception {
-  override var reason: String {
-    "An unknown exception occured"
-  }
+  // Don't override reason - use the description passed to the initializer
+  // This allows propagating the actual error message from ASAuthorizationError
 }
 
 internal class InvalidLargeBlobWriteInputException: Exception {
   override var reason: String {
     "The provided large blob write input was invalid"
   }
+}
+
+internal class MatchedExcludedCredentialException: Exception {
+  // Don't override reason - use the description passed to the initializer
+  // This will contain the localized message from iOS about the matched credential
+}
+
+internal class InvalidResponseException: Exception {
+  // Don't override reason - use the description passed to the initializer
+  // Maps to WebAuthn EncodingError
+}
+
+internal class NotHandledException: Exception {
+  // Don't override reason - use the description passed to the initializer
+  // Maps to WebAuthn NotSupportedError
+}
+
+internal class NotInteractiveException: Exception {
+  // Don't override reason - use the description passed to the initializer
+  // Maps to WebAuthn InvalidStateError
 }


### PR DESCRIPTION
## Summary

Fixes #45 - excludeCredentials does not return expected InvalidStateError message when credential already exists

This PR enhances iOS error handling to provide clear, descriptive error messages instead of generic "(null)" or "The operation couldn't be completed" messages.

## Changes

- **Enhanced error detection**: Added logic to detect generic/useless error messages from iOS
- **WebAuthn compliance**: Maps ASAuthorizationError codes to proper WebAuthn error names (NotAllowedError, EncodingError, NotSupportedError, OperationError, InvalidStateError)
- **Descriptive messages**: Provides clear error messages for all error cases, including the new iOS 18.0+ ASAuthorizationErrorMatchedExcludedCredential (error code 1006)
- **Test support**: Added example app test button to verify excludeCredentials error handling

## Files Changed

- `ios/PasskeyExceptions.swift`: Added new exception classes for different error types
- `ios/ReactNativePasskeysModule.swift`: Enhanced `handleASAuthorizationError` function with generic error detection and proper error mapping
- `example/src/app/index.tsx`: Added test button to demonstrate excludeCredentials error handling

## Testing

Run the example app and use the new "Test excludeCredentials" button to verify that attempting to create a credential that's already registered returns a proper InvalidStateError with a descriptive message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved iOS error handling for WebAuthn operations with better detection and mapping of native errors.
  * Enhanced error messages for excludeCredentials scenarios and other WebAuthn edge cases, providing more descriptive feedback to users on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->