### PR TITLE
Fix JVM target mismatch on AGP 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,22 +53,7 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_17
-    targetCompatibility JavaVersion.VERSION_17
-  }
-
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_17.majorVersion
-    }
-  }
+  kotlin.jvmToolchain(17)
 
   namespace "expo.modules.passkeys"
   defaultConfig {


### PR DESCRIPTION
Targeted (partial?) replacement for #59

The kotlinOptions block that sets jvmTarget to 17 was only applied inside an `if (agpVersion < 8)` guard, presumably assuming AGP 8+ would automatically propagate the Java compileOptions target to Kotlin. It does not - that only happens when using jvmToolchain().

On AGP 8+ with Kotlin 2.x (which defaults to JVM target 21), this caused a build failure:

```
$ ./gradlew :react-native-passkeys:compileDebugKotlin
[...]
> ❌ Inconsistent JVM Target Compatibility Between Java and Kotlin Tasks
  Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21).

  Consider using JVM Toolchain: https://kotl.in/gradle/jvm/toolchain
  Learn more about JVM-target validation: https://kotl.in/gradle/jvm/target-validation
```

Replace the version-guarded compileOptions/kotlinOptions blocks with a single `kotlin.jvmToolchain(17)` call, which is the approach used by both React Native (ReactAndroid) and expo-modules-core. This sets both Java and Kotlin compilation targets in one place, eliminating the mismatch regardless of AGP version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized the Android build system configuration for improved stability, consistency, and predictability across all development and production environments. Consolidated Java version compatibility handling and removed unnecessary conditional build logic to streamline the build process. These infrastructure updates ensure more reliable builds, strengthen maintainability, and reduce build complexity while preserving all existing user functionality and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->