### PR TITLE
fix: add correctly-spelled isAutoFillAvailable and deprecate isAutoFillAvalilable

### DIFF
--- a/src/ReactNativePasskeysModule.web.ts
+++ b/src/ReactNativePasskeysModule.web.ts
@@ -19,7 +19,12 @@ export default {
 		return "ReactNativePasskeys";
 	},
 
+	/** @deprecated use `isAutoFillAvailable` */
 	isAutoFillAvalilable(): Promise<boolean> {
+		return this.isAutoFillAvailable();
+	},
+
+	isAutoFillAvailable(): Promise<boolean> {
 		return window.PublicKeyCredential.isConditionalMediationAvailable?.() ?? Promise.resolve(false);
 	},
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,13 @@ export function isSupported(): boolean {
 	return ReactNativePasskeysModule.isSupported();
 }
 
+export function isAutoFillAvailable(): boolean {
+	return ReactNativePasskeysModule.isAutoFillAvailable();
+}
+
+/** @deprecated use `isAutoFillAvailable` */
 export function isAutoFillAvalilable(): boolean {
-	return ReactNativePasskeysModule.isAutoFillAvalilable();
+	return isAutoFillAvailable();
 }
 
 export async function create(


### PR DESCRIPTION
## Summary
- Adds a correctly-spelled `isAutoFillAvailable()` function/method as the canonical API
- Marks the existing `isAutoFillAvalilable()` (typo) as `@deprecated` with a pointer to the new name
- The deprecated method delegates to the new one, so existing callers are unaffected

## Test Plan
- [x] Verify `isAutoFillAvailable()` works on web (calls `PublicKeyCredential.isConditionalMediationAvailable`)
- [x] Verify existing callers using the old spelling still work without changes

## Context
The original `isAutoFillAvalilable` had a doubled `l` in "Available" — this PR introduces the corrected spelling while maintaining full backwards compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `isAutoFillAvailable()` method.

* **Deprecations**
  * Deprecated `isAutoFillAvalilable()` method; use `isAutoFillAvailable()` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->